### PR TITLE
Fix panic in dialect. If FK Id is not referenced

### DIFF
--- a/qbs.go
+++ b/qbs.go
@@ -215,6 +215,9 @@ func (q *Qbs) scanRows(rowValue reflect.Value, rows *sql.Rows) (err error) {
 	}
 	for i, v := range containers {
 		value := reflect.Indirect(reflect.ValueOf(v))
+		if value.Elem().IsValid() {
+			continue
+		}
 		key := cols[i]
 		paths := strings.Split(key, "___")
 		if len(paths) == 2 {


### PR DESCRIPTION
Hello,

Can you review this patch.
I'm not sure to make a side effect on this one...

``` shell
panic: reflect: call of reflect.Value.Int on zero Value

goroutine 1 [running]:
reflect.Value.Int(0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /opt/golang/src/pkg/reflect/value.go:796 +0xd0
github.com/coocood/qbs.(*Sqlite3).SetModelValue(0xf84008c570, 0x4c47b0, 0xf8400a6270, 0x146, 0x4c6750, ...)
    [...]/github.com/coocood/qbs/sqlite3.go:51 +0x33c
github.com/coocood/qbs.(*Qbs).scanRows(0xf84008b280, 0x4c1e80, 0xf8400a06c0, 0x160, 0xf8400a4a80, ...)
    [...]/github.com/coocood/qbs/qbs.go:225 +0x83e
github.com/coocood/qbs.(*Qbs).doQueryRow(0xf84008b280, 0x4c1e70, 0xf8400a06c0, 0xf8400a7340, 0xf800000338, ...)
    [...]/github.com/coocood/qbs/qbs.go:167 +0x377
github.com/coocood/qbs.(*Qbs).Find(0xf84008b280, 0x4c1e70, 0xf8400a06c0, 0xf8400a06c0, 0x100000001, ...)
    [...]/github.com/coocood/qbs/qbs.go:139 +0x349
```

If Id in FK isn't on database.

Regards.

In other possible patch is: 

``` patch
diff --git a/qbs.go b/qbs.go
index 2fa4bfd..d6ca513 100644
--- a/qbs.go
+++ b/qbs.go
@@ -226,7 +226,7 @@ func (q *Qbs) scanRows(rowValue reflect.Value, rows *sql.Rows) (err error) {
                                subStruct.Set(reflect.New(subStruct.Type().Elem()))
                        }
                        subField := subStruct.Elem().FieldByName(snakeToUpperCamel(paths[1]))
-                       if subField.IsValid() {
+                       if subField.IsValid() && value.Elem().IsValid() {
                                err = q.Dialect.SetModelValue(value, subField)
                                if err != nil {
                                        return

```
