### PR TITLE
Add IndexExists() support to PostgreSQL dialect.

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"database/sql"
 )
 
 type postgres struct {
@@ -80,7 +81,13 @@ func (d *postgres) KeywordAutoIncrement() string {
 }
 
 func (d *postgres) IndexExists(mg *Migration, tableName, indexName string) bool {
-	return false
+	var row *sql.Row
+	var name string
+	query := "SELECT indexname FROM pg_indexes"
+	query += "WHERE tablename = ? AND indexname = ?"
+	row = mg.Db.QueryRow(query, tableName, indexName)
+	err := row.Scan(&name)
+	return err != nil
 }
 
 func (d *postgres) SubstituteMarkers(query string) string {


### PR DESCRIPTION
Before, calling `CreateTableIfNotExists()` on a struct with indexed fields resulted in an error if the table already existed, e.g.:

```
2013/03/13 01:39:24 pq: S:"ERROR" F:"index.c" C:"42P07" L:"774" M:"relation \"email\" already exists" R:"index_create"
```

Now Postgres dialect can check to see if an index already exists.
