### PR TITLE
Create indexes using "tableName_columns" instead of "columns" as name.

### DIFF
--- a/model.go
+++ b/model.go
@@ -88,12 +88,12 @@ func (model *Model) columnsAndValues(forUpdate bool) ([]string, []interface{}) {
 			include = column.Value != nil && !column.PK
 		} else {
 			include = true
-			if column.Value == nil{
+			if column.Value == nil {
 				include = false
-			}else if column.PK {
-				if intValue,ok := column.Value.(int64); ok{
+			} else if column.PK {
+				if intValue, ok := column.Value.(int64); ok {
 					include = intValue != 0
-				}else if strValue, ok := column.Value.(string); ok{
+				} else if strValue, ok := column.Value.(string); ok {
 					include = strValue != ""
 				}
 			}


### PR DESCRIPTION
This allows us to create different tables that have indexed fields with the same name.  For example a table `foo` with an indexed field `elvis`, and table `bar` also with an indexed field named `elvis`.  Before, qbs would try to name both indexes `elvis`, and fail trying to create the second one.  Now it will name them `foo_elvis` and `bar_elvis` respectively.
