### PR TITLE
Allow custom structs for model fields through sql.Scanner interface

### DIFF
--- a/base.go
+++ b/base.go
@@ -75,6 +75,9 @@ func (d base) setModelValue(driverValue, fieldValue reflect.Value) error {
 			str := string(driverValue.Elem().Bytes())
 			fieldValue.Set(reflect.ValueOf(sql.NullString{str, true}))
 		}
+		if scanner, ok := fieldValue.Addr().Interface().(sql.Scanner); ok {
+			return scanner.Scan(driverValue.Interface())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
I'd like to use some non-standard datatypes that are available in Postgresql (array, hstore) in my models, so sql.Scanner seems like a good candidate that will allow to use custom structs for that. This is very similar to sql.NullInt64 or sql.NullBool types. The model will looks like this:

``` Go
type ModelMetadata struct {
    Id         int `qbs:"pk"`
    Tags      PgStringArray
}
```

And custom datatype like this:

``` Go
type PgStringArray struct {
    Value []string
}

func (arr *PgStringArray) Scan(src interface{}) error {
    // convert src to arr.Value array
    return nil
}
```

The conversion itself will be handled separately.

Does it makes sense?
