### PR TITLE
Use sql.Scanner interface for sql.Null* types during model value setting

### DIFF
--- a/base.go
+++ b/base.go
@@ -60,24 +60,12 @@ func (d base) setModelValue(driverValue, fieldValue reflect.Value) error {
 		switch fieldValue.Interface().(type) {
 		case time.Time:
 			fieldValue.Set(driverValue.Elem())
-		case sql.NullBool:
-			b := d.dialect.parseBool(driverValue.Elem())
-			fieldValue.Set(reflect.ValueOf(sql.NullBool{b, true}))
-		case sql.NullFloat64:
-			if f, ok := driverValue.Elem().Interface().(float64); ok {
-				fieldValue.Set(reflect.ValueOf(sql.NullFloat64{f, true}))
+		default:
+			if scanner, ok := fieldValue.Addr().Interface().(sql.Scanner); ok {
+				return scanner.Scan(driverValue.Interface())
 			}
-		case sql.NullInt64:
-			if i, ok := driverValue.Elem().Interface().(int64); ok {
-				fieldValue.Set(reflect.ValueOf(sql.NullInt64{i, true}))
-			}
-		case sql.NullString:
-			str := string(driverValue.Elem().Bytes())
-			fieldValue.Set(reflect.ValueOf(sql.NullString{str, true}))
 		}
-		if scanner, ok := fieldValue.Addr().Interface().(sql.Scanner); ok {
-			return scanner.Scan(driverValue.Interface())
-		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
Since sql.NullBool, sql.NullFloat64, sql.NullInt64 and sql.NullString implement sql.Scanner - no need to treat them separately.
