### PR TITLE
Pluralizing Table Names

### DIFF
--- a/model.go
+++ b/model.go
@@ -3,8 +3,6 @@ package qbs
 import (
 	"bytes"
 	"database/sql"
-	"fmt"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"


### PR DESCRIPTION
My application required that I modify qbs to pluralize table names so I forked it, implemented optional table name pluralizing (flagged by qbs.PluralizeTableNames) and thought I would share the change with the developers. 
