### PR TITLE
Allow existing *sql.DB to be registered to qbs ORM

### DIFF
--- a/qbs.go
+++ b/qbs.go
@@ -38,20 +38,26 @@ type Validator interface {
 
 //Register a database, should be call at the beginning of the application.
 func Register(driverName, driverSourceName, databaseName string, dialect Dialect) {
-	driver = driverName
 	driverSource = driverSourceName
-	dial = dialect
 	dbName = databaseName
 	if db == nil {
 		var err error
-		db, err = sql.Open(driver, driverSource)
+		var database *sql.DB
+		database, err = sql.Open(driver, driverSource)
 		if err != nil {
 			panic(err)
 		}
-		db.SetMaxIdleConns(100)
-		stmtMap = make(map[string]*sql.Stmt)
-		mu = new(sync.RWMutex)
+		RegisterWithDb(driverName, database, dialect)
 	}
+}
+
+func RegisterWithDb(driverName string, database *sql.DB, dialect Dialect) {
+	driver = driverName
+	dial = dialect
+	db = database
+	db.SetMaxIdleConns(100)
+	stmtMap = make(map[string]*sql.Stmt)
+	mu = new(sync.RWMutex)
 }
 
 //A safe and easy way to work with *Qbs instance without the need to open and close it.


### PR DESCRIPTION
Separated qbs.Register function such that assigning the db variable and connecting to a database are handled in two different functions, allowing a user to easily hook up an already established *sql.DB to use the qbs ORM.
