### PR TITLE
fixing bug in Register()

### DIFF
--- a/qbs.go
+++ b/qbs.go
@@ -43,7 +43,7 @@ func Register(driverName, driverSourceName, databaseName string, dialect Dialect
 	if db == nil {
 		var err error
 		var database *sql.DB
-		database, err = sql.Open(driver, driverSource)
+		database, err = sql.Open(driverName, driverSource)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
when RegisterWithDB was created, the setting of the driver variable was moved from Register, this caused the opening of the SQL connection to not have a driver string ultimately causing this call to fail. since driver is created outside of the function scope, this passes a compile. 

replaced 'driver' with 'driverName' which fixes the issue
