### PR TITLE
struct can control table name

### DIFF
--- a/model.go
+++ b/model.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+type TableNamer interface {
+	TableName() string
+}
+
 const QBS_COLTYPE_INT = "int"
 const QBS_COLTYPE_BOOL = "boolean"
 const QBS_COLTYPE_BIGINT = "bigint"
@@ -291,6 +295,9 @@ func tableName(talbe interface{}) string {
 		if !c {
 			break
 		}
+	}
+	if tn, ok := talbe.(TableNamer); ok {
+		return tn.TableName()
 	}
 	return StructNameToTableName(t.Name())
 }


### PR DESCRIPTION
created an interface that if a struct implements it, it can set the table name

I think this is pretty non-invasive and is highly useful if you have some some tables where the table name is dynamically chosen but the table structure is known.  For example (postgres)

```
create table foo (...);
create table foo_123456 like foo;
```

if you want then to use a `struct foo {...}` in your program, you need this type of approach.

hope it helps,
ian
