### PR TITLE
Allow nullable fields

### DIFF
--- a/base.go
+++ b/base.go
@@ -34,6 +34,21 @@ func (d base) parseBool(value reflect.Value) bool {
 	return value.Bool()
 }
 
+func (d base) setPtrValue(driverValue, fieldValue reflect.Value) {
+	t := fieldValue.Type().Elem()
+	v := reflect.New(t)
+	fieldValue.Set(v)
+	switch t.Kind() {
+	case reflect.String:
+		v.Elem().SetString(string(driverValue.Interface().([]uint8)))
+	case reflect.Int64:
+		v.Elem().SetInt(driverValue.Interface().(int64))
+	case reflect.Float64:
+		v.Elem().SetFloat(driverValue.Interface().(float64))
+	case reflect.Bool:
+		v.Elem().SetBool(driverValue.Interface().(bool))
+	}
+}
 func (d base) setModelValue(driverValue, fieldValue reflect.Value) error {
 	switch fieldValue.Type().Kind() {
 	case reflect.Bool:
@@ -56,6 +71,8 @@ func (d base) setModelValue(driverValue, fieldValue reflect.Value) error {
 		if reflect.TypeOf(driverValue.Interface()).Elem().Kind() == reflect.Uint8 {
 			fieldValue.SetBytes(driverValue.Elem().Bytes())
 		}
+	case reflect.Ptr:
+		d.setPtrValue(driverValue, fieldValue)
 	case reflect.Struct:
 		switch fieldValue.Interface().(type) {
 		case time.Time:

--- a/mysql.go
+++ b/mysql.go
@@ -35,7 +35,11 @@ func (d mysql) parseBool(value reflect.Value) bool {
 func (d mysql) sqlType(field modelField) string {
 	f := field.value
 	fieldValue := reflect.ValueOf(f)
-	switch fieldValue.Kind() {
+	kind := fieldValue.Kind()
+	if field.nullable != reflect.Invalid {
+		kind = field.nullable
+	}
+	switch kind {
 	case reflect.Bool:
 		return "boolean"
 	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint8, reflect.Uint16, reflect.Uint32:

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -224,6 +224,11 @@ func TestMysqlDataSourceName(t *testing.T) {
 	assert.Equal("john:123@unix(192.168.1.3:3336)/abc?charset=utf8&parseTime=true", dsn)
 }
 
+func TestMysqlSaveNullable(t *testing.T) {
+	mg, q := setupMysqlDb()
+	doTestSaveNullable(NewAssert(t), mg, q)
+}
+
 func BenchmarkMysqlFind(b *testing.B) {
 	registerMysqlTest()
 	doBenchmarkFind(b, b.N)

--- a/postgres.go
+++ b/postgres.go
@@ -45,7 +45,11 @@ func (d postgres) quote(s string) string {
 func (d postgres) sqlType(field modelField) string {
 	f := field.value
 	fieldValue := reflect.ValueOf(f)
-	switch fieldValue.Kind() {
+	kind := fieldValue.Kind()
+	if field.nullable != reflect.Invalid {
+		kind = field.nullable
+	}
+	switch kind {
 	case reflect.Bool:
 		return "boolean"
 	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint8, reflect.Uint16, reflect.Uint32:

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -187,6 +187,11 @@ func TestPgDropTableSQL(t *testing.T) {
 	doTestDropTableSQL(NewAssert(t), pgSyntax)
 }
 
+func TestPgSaveNullable(t *testing.T) {
+	mg, q := setupPgDb()
+	doTestSaveNullable(NewAssert(t), mg, q)
+}
+
 func TestPgDataSourceName(t *testing.T) {
 	dsn := new(DataSourceName)
 	dsn.DbName = "abc"

--- a/sqlite3.go
+++ b/sqlite3.go
@@ -27,7 +27,11 @@ func RegisterSqlite3(dbFileName string) {
 func (d sqlite3) sqlType(field modelField) string {
 	f := field.value
 	fieldValue := reflect.ValueOf(f)
-	switch fieldValue.Kind() {
+	kind := fieldValue.Kind()
+	if field.nullable != reflect.Invalid {
+		kind = field.nullable
+	}
+	switch kind {
 	case reflect.Bool:
 		return "integer"
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
@@ -106,6 +110,8 @@ func (d sqlite3) setModelValue(value reflect.Value, field reflect.Value) error {
 		if reflect.TypeOf(value.Interface()).Elem().Kind() == reflect.Uint8 {
 			field.SetBytes(value.Elem().Bytes())
 		}
+	case reflect.Ptr:
+		d.setPtrValue(value, field)
 	case reflect.Struct:
 		switch field.Interface().(type) {
 		case time.Time:

--- a/sqlite3_test.go
+++ b/sqlite3_test.go
@@ -258,6 +258,11 @@ func TestSqlite3DropTableSQL(t *testing.T) {
 	doTestDropTableSQL(NewAssert(t), sqlite3Syntax)
 }
 
+func TestSqlite3SaveNullable(t *testing.T) {
+	mg, q := setupSqlite3Db()
+	doTestSaveNullable(NewAssert(t), mg, q)
+}
+
 func BenchmarkSqlite3Find(b *testing.B) {
 	registerSqlite3Test()
 	doBenchmarkFind(b, b.N)


### PR DESCRIPTION
This is a small patch that is built on my previous PR.   This PR allows the field values to be null if the struct defines the fields to be pointers to one of the four types that the DB driver interface requires to be nullable.
