### PR TITLE
improve error message in a common case

### DIFF
--- a/model.go
+++ b/model.go
@@ -175,6 +175,11 @@ func structPtrToModel(f interface{}, root bool, omitFields []string) *model {
 	}
 	structType := reflect.TypeOf(f).Elem()
 	structValue := reflect.ValueOf(f).Elem()
+	if structType.Kind() == reflect.Ptr {
+		if structType.Elem().Kind() == reflect.Struct {
+			panic("did you pass a pointer to a pointer to a struct?")
+		}
+	}
 	for i := 0; i < structType.NumField(); i++ {
 		structField := structType.Field(i)
 		omit := false


### PR DESCRIPTION
I have found this to be a common error mode that produces a hard to understand error if left alone.

This doesn't change the behavior, there is a panic in any case immediately after this.
