### PR TITLE
Return errors in QueryRow properly

### DIFF
--- a/oracle.go
+++ b/oracle.go
@@ -80,9 +80,11 @@ func (d oracle) sqlType(field modelField) string {
 
 func (d oracle) insert(q *Qbs) (int64, error) {
 	sql, args := d.dialect.insertSql(q.criteria)
-	row := q.QueryRow(sql, args...)
+	row, err := q.QueryRow(sql, args...)
+	if err != nil {
+		return 0, err
+	}
 	value := q.criteria.model.pk.value
-	var err error
 	var id int64
 	if _, ok := value.(int64); ok {
 		err = row.Scan(&id)

--- a/postgres.go
+++ b/postgres.go
@@ -113,9 +113,11 @@ func (d postgres) sqlType(field modelField) string {
 
 func (d postgres) insert(q *Qbs) (int64, error) {
 	sql, args := d.dialect.insertSql(q.criteria)
-	row := q.QueryRow(sql, args...)
+	row, err := q.QueryRow(sql, args...)
+	if err != nil {
+		return 0, err
+	}
 	value := q.criteria.model.pk.value
-	var err error
 	var id int64
 	if _, ok := value.(int64); ok {
 		err = row.Scan(&id)


### PR DESCRIPTION
* oracle.go: Handle QueryRow multiple return values
* postgres.go: Handle QueryRow multiple return values
* qbs.go: Return an error during QueryRow

This fixes a panic in the qbs.Count and qbs.ContainsValue implementation

Signed-off-by: Jeff Mickey <j@codemac.net>