### PR TITLE
Fix for issue with sqlite3 datetime parsing

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -47,7 +47,7 @@ func (d sqlite3) sqlType(field modelField) string {
 	case reflect.Struct:
 		switch fieldValue.Interface().(type) {
 		case time.Time:
-			return "text"
+			return "datetime"
 		case sql.NullBool:
 			return "integer"
 		case sql.NullInt64:
@@ -66,7 +66,7 @@ func (d sqlite3) sqlType(field modelField) string {
 				case QBS_COLTYPE_BOOL:
 					return "integer"
 				case QBS_COLTYPE_TIME:
-					return "text"
+					return "datetime"
 				case QBS_COLTYPE_DOUBLE:
 					return "real"
 				case QBS_COLTYPE_TEXT:


### PR DESCRIPTION
Fix for error `parsing time "2015-12-02 19:15:53.964608741-08:00": extra text: -08:00` when loading time.Time fields from sqlite3 TEXT fields