### PR TITLE
Fix a string conversion bug that appeared between Go 1.3 and 1.7

### DIFF
--- a/base.go
+++ b/base.go
@@ -66,7 +66,7 @@ func (d base) setModelValue(driverValue, fieldValue reflect.Value) error {
 	case reflect.Float32, reflect.Float64:
 		fieldValue.SetFloat(driverValue.Elem().Float())
 	case reflect.String:
-		fieldValue.SetString(string(driverValue.Elem().Bytes()))
+		fieldValue.SetString(driverValue.Elem().String())
 	case reflect.Slice:
 		if reflect.TypeOf(driverValue.Interface()).Elem().Kind() == reflect.Uint8 {
 			fieldValue.SetBytes(driverValue.Elem().Bytes())


### PR DESCRIPTION
Hi, when I upgraded from go 1.3 to 1.7.* I found that this byte to string conversion stopped working, but when I call .String() on the element everything works as expected.