### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Qbs stands for Query By Struct. A Go ORM. [中文版 README](https://github.com/
 
 [![Build Status](https://drone.io/github.com/coocood/qbs/status.png)](https://drone.io/github.com/coocood/qbs/latest)
 
-##ChangeLog
+## ChangeLog
 
 * 2013.03.14: index name has changed to `{table name}_{column name}`.
     - For existing application with existing database, update to this change may lead to creating redundant index, you may need to drop duplicated index manually.
@@ -18,7 +18,7 @@ Qbs stands for Query By Struct. A Go ORM. [中文版 README](https://github.com/
 * 2013.05.29: Added `Iterate` method for processing large data without loading all rows into memory.
 * 2013.08.03: Fixed a bug that exceeds max_prepared_stmt_count
 
-##Features
+## Features
 
 * Define table schema in struct type, create table if not exists.
 * Detect table columns in database and alter table add new column automatically.
@@ -38,7 +38,7 @@ Qbs stands for Query By Struct. A Go ORM. [中文版 README](https://github.com/
 `Qbs.Find` is about 60% faster on mysql, 130% faster on postgreSQL than raw `Db.Query`, about 20% slower than raw `Stmt.Query`. (benchmarked on windows).
 The reason why it is faster than `Db.Query` is because all prepared Statements are cached in map.
 
-##Install
+## Install
 
 Only support go 1.1+
 
@@ -57,9 +57,9 @@ tags with different minor version would break compatibility, e.g `v0.1.1` and `v
 
 See [Gowalker](http://gowalker.org/github.com/coocood/qbs) for complete documentation.
 
-##Get Started
+## Get Started
 
-###First you need to register your database
+### First you need to register your database
 
 * The `qbs.Register` function has two more arguments than `sql.Open`, they are database name and dilect instance.
 * You only need to call it once at the start time..
@@ -86,7 +86,7 @@ if you want define a primary key with name other than `Id`, you can set the tag 
             //indexes.Add("column_a", "column_b") or indexes.AddUnique("column_a", "column_b")
         }
 
-###Create a new table
+### Create a new table
 
 - call `qbs.GetMigration` function to get a Migration instance, and then use it to create a table.
 - When you create a table, if the table already exists, it will not recreate it, but looking for newly added columns or indexes in the model, and execute add column or add index operation.
@@ -249,13 +249,13 @@ so whenever you pass a column name or table name parameter in string, it should 
         	return posts, err
         }
 
-##Projects use Qbs:
+## Projects use Qbs:
 
 - a CMS system [toropress](https://github.com/insionng/toropress)
 - Go documentation reference website [Gowalker](http://gowalker.org/)
 - Nebri OS (https://nebrios.com/)
 
-##Contributors
+## Contributors
 [Erik Aigner](https://github.com/eaigner)
 Qbs was originally a fork from [hood](https://github.com/eaigner/hood) by [Erik Aigner](https://github.com/eaigner), 
 but I changed more than 80% of the code, then it ended up become a totally different ORM.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -3,7 +3,7 @@ Qbs
 
 Qbs是一个Go语言的ORM
 
-##特性
+## 特性
 
 * 支持通过struct定义表结构，自动建表。
 * 如果表已经存在，而struct定义了新的字段，Qbs会自动向数据库表添加相应的字段。
@@ -18,22 +18,22 @@ Qbs是一个Go语言的ORM
 * 目前支持MySQL， PosgreSQL， SQLite3，即将支持Oracle。
 * 支持连接池。
 
-##安装
+## 安装
 
     go get github.com/coocood/qbs
 
-##API文档
+## API文档
 
 [GoDoc](http://godoc.org/github.com/coocood/qbs)
 
-##注意
+## 注意
 
 * 新的版本可能会不兼容旧的API，使旧程序不能正常工作。
 * 一次go get下载后，请保留当时的版本，如果需要其它机器上编辑，请复制当时的版本，不要在新的机器上通过go get来下载最新版本。
 * 或者Fork一下，版本的更新自己来掌握。
 * 每一次进行有可能破坏兼容性的更新时，会把之前的版本保存为一个新的branch, 名字是更新的日期。
 
-##使用手册
+## 使用手册
 
 
 ### 首先要注册数据库：
@@ -250,4 +250,4 @@ Qbs是一个Go语言的ORM
         	return posts, err
         }
 
-。。。未完代续
+。。。未完代


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
